### PR TITLE
Implementing Generalized linear mixed models

### DIFF
--- a/shapeout/lin_mix_mod.py
+++ b/shapeout/lin_mix_mod.py
@@ -103,10 +103,13 @@ def linmixmod(xs, treatment, timeunit, model, RCMD=cran.rcmd):
         Each item is a description/identifier for a time. The
         enumeration matches the index of `xs`.
         (e.g. list containing integers "1" and "2" according to the day
-        at which the content in `xs` was measured)          
+        at which the content in `xs` was measured) 
+    model: string
+        'lmm': A linear mixed model will be applied
+        'glmm': A generalized linear mixed model will be applied
     Returns
     -------
-    Linear Mixed Effects Model Result: dictionary
+    (Generalized) Linear Mixed Effects Model Result: dictionary
     The dictionary contains:
     -Estimate:  the average value of cells that had Treatment 1
     -Fixed Effect: Change of the estimate value due to the Treatment 2
@@ -251,10 +254,10 @@ def linmixmod(xs, treatment, timeunit, model, RCMD=cran.rcmd):
         timeunit = np.array(TimeUnit)          
 
     else: #If there is no 'Reservoir Channel' selected dont apply bootstrapping
-        if model==1:
+        if model=='glmm':
             Head_string = "GENERALIZED LINEAR MIXED MODEL: \n " +\
             "---Results are in log space (loglink was used)--- \n "
-        if model==0:
+        if model=='lmm':
             Head_string = "LINEAR MIXED MODEL: \n "
             
         for i in range(len(xs)): 
@@ -288,10 +291,10 @@ def linmixmod(xs, treatment, timeunit, model, RCMD=cran.rcmd):
                       )
 
     #Random intercept and random slope model
-    if model==1:
+    if model=='glmm':
         r1("Model = glmer("+modelfunc+",RTDC,family=Gamma(link='log'))")
         r1("NullModel = glmer("+nullmodelfunc+",RTDC,family=Gamma(link='log'))")
-    if model==0:
+    if model=='lmm':
         r1("Model = lmer("+modelfunc+",RTDC)")
         r1("NullModel = lmer("+nullmodelfunc+",RTDC)")
 
@@ -344,9 +347,9 @@ def linmixmod(xs, treatment, timeunit, model, RCMD=cran.rcmd):
     "\nEstimate = \t"+str(estim_y)+\
     "\nFixed effect = \t"+str(fixef_y)
     
-    if model==1:
+    if model=='glmm':
         full_summary = full_summary_gemmixmod
-    if model==0:
+    if model=='lmm':
         full_summary = full_summary_linmixmod
         
     results = {"Full Summary":full_summary,

--- a/shapeout/lin_mix_mod.py
+++ b/shapeout/lin_mix_mod.py
@@ -65,7 +65,7 @@ def diffdef(y, yR, bs_iter=DEFAULT_BS_ITER, rs=117):
     return [Median,MedianR]
 
 
-def linmixmod(xs, treatment, timeunit, model, RCMD=cran.rcmd):
+def linmixmod(xs, treatment, timeunit, model='lmm', RCMD=cran.rcmd):
     '''
     Linear Mixed-Effects Model computation for one fixed effect and one 
     random effect.
@@ -149,7 +149,7 @@ def linmixmod(xs, treatment, timeunit, model, RCMD=cran.rcmd):
     timeunit1 = [1, 1, 2, 2, 1, 1, 2, 2]
     
     #Example 1: linear mixed models on differential deformations
-    Result_1 = linmixmod(xs=xs,treatment=treatment1,timeunit=timeunit1,model=0)
+    Result_1 = linmixmod(xs=xs,treatment=treatment1,timeunit=timeunit1,model='lmm')
 
     #Result_1:Estimate=93.69375 (i.e. the average Control value is 93.69)
     #         FixedEffect=43.93 (i.e. The treatment leads to an increase)         
@@ -162,7 +162,7 @@ def linmixmod(xs, treatment, timeunit, model, RCMD=cran.rcmd):
     treatment2 = ['Treatment', 'Control', 'Treatment', 'Control',\
     'Treatment', 'Control','Treatment', 'Control']
     timeunit2 = [1, 1, 2, 2, 3, 3, 4, 4]
-    Result_2 = linmixmod(xs=xs,treatment=treatment2,timeunit=timeunit2,model=0)
+    Result_2 = linmixmod(xs=xs,treatment=treatment2,timeunit=timeunit2,model='lmm')
     
     #Result_2:Estimate=17.17 (i.e. the average Control value is 17.17 )
     #         FixedEffect=120.257 (i.e. The treatment leads to an increase)         
@@ -173,7 +173,7 @@ def linmixmod(xs, treatment, timeunit, model, RCMD=cran.rcmd):
     treatment3 = ['Treatment', 'Control', 'Treatment', 'Control',\
     'Treatment', 'Control','Treatment', 'Control']
     timeunit3 = [1, 1, 2, 2, 3, 3, 4, 4]    
-    Result_3 = linmixmod(xs=xs,treatment=treatment3,timeunit=timeunit3,model=1)
+    Result_3 = linmixmod(xs=xs,treatment=treatment3,timeunit=timeunit3,model='glmm')
     
     #Result_3:Estimate=2.71 (i.e. the average Control value is exp(2.71)=15.08)
     #         FixedEffect=2.19 (i.e. The treatment leads to an increase)         


### PR DESCRIPTION
I have added the variable "model" to the function linmixmod, which allows to perfom either a linear mixed model (model=0) or a generalized linear mixed model (GLMM) with a log-link function (model=1). GLMM might be better suited for skewed distributions like deformation. The user should be able to decide which model should be applied. Therefore I suggest a dropdown menu for LMM and GLMM