### PR TITLE
Perform log-scaling before computing density

### DIFF
--- a/shapeout/gui/plot_scatter.py
+++ b/shapeout/gui/plot_scatter.py
@@ -187,11 +187,22 @@ def scatter_plot(measurement,
 
     return sc_plot
 
+def scaling(x,scale):
+    if scale=='log':
+        return np.log(x)
+    elif scale=="linear":
+        return x
+    else:
+        raise ValueError("Invalid argument for scale. Valid arguments are 'linear' and 'log'!")
+        
 
 def set_scatter_data(plot, mm):
     plotfilters = mm.config.copy()["plotting"]
     xax = mm.config["plotting"]["axis x"].lower()
     yax = mm.config["plotting"]["axis y"].lower()
+    
+    scalex = mm.config["plotting"]["scale x"].lower()
+    scaley = mm.config["plotting"]["scale y"].lower()
     
     x0 = mm[xax][mm.filter.all]
 
@@ -204,13 +215,13 @@ def set_scatter_data(plot, mm):
         positions = None
     else:
         print("...Downsampled from {} to {} in {:.2f}s".format(lx, x.shape[0], time.time()-a))
-        positions = np.vstack([x.ravel(), y.ravel()])
-
+        #Apply log-scaling before density is computed     
+        positions = np.vstack([scaling(x.ravel(),scalex), scaling(y.ravel(),scaley)])
 
     kde_type = mm.config["plotting"]["kde"].lower()
     kde_kwargs = plot_common.get_kde_kwargs(x=x, y=y, kde_type=kde_type,
-                                            xacc=mm.config["plotting"]["kde accuracy "+xax],
-                                            yacc=mm.config["plotting"]["kde accuracy "+yax])
+                                            xacc=scaling(mm.config["plotting"]["kde accuracy "+xax],scalex),
+                                            yacc=scaling(mm.config["plotting"]["kde accuracy "+yax],scaley))
     
     a = time.time()
     density = mm.get_kde_scatter(xax=xax, yax=yax, positions=positions,


### PR DESCRIPTION
Currently, the density plots look very awkward when plotting in log-space. This is because the log-transformation changes the spacing between positions. The proposed change introduces a "scaling" function, which is used to perform the scaling for x and y or both if necessary. The kde-accuracies are adjusted as well (xacc and yacc)