### PR TITLE
0.9.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.9.6
+ - enh: improved support for .tdms file format (dclab 0.14.3)
  - fix: remove nan/inf values before performing (g)lmm analysis (#248)
  - docs: request citation of Herbig2018 when performing (g)lmm analysis
 0.9.5

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 0.9.6
- - enh: improved support for .tdms file format (dclab 0.12.0 -> 0.14.4)
+ - enh: improved support for tdms data (dclab 0.12.0 -> 0.14.4) (e.g. #249)
  - fix: remove nan/inf values before performing (g)lmm analysis (#248)
  - docs: request citation of Herbig2018 when performing (g)lmm analysis
 0.9.5

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 0.9.6
- - enh: improved support for tdms data (dclab 0.12.0 -> 0.14.6) (e.g. #249)
+ - enh: improved support for tdms data (dclab 0.12.0 -> 0.14.7) (e.g. #249)
+ - enh: write Shape-Out version to exported .fcs and .tsv files (#250)
  - fix: remove nan/inf values before performing (g)lmm analysis (#248)
  - docs: request citation of Herbig2018 when performing (g)lmm analysis
 0.9.5

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 0.9.6
  - fix: remove nan/inf values before performing (g)lmm analysis (#248)
+ - docs: request citation of Herbig2018 when performing (g)lmm analysis
 0.9.5
  - fix: Allow to open measurement files that do not contain the features
    "area_um" or "deform" (#245)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 0.9.6
- - enh: improved support for tdms data (dclab 0.12.0 -> 0.14.4) (e.g. #249)
+ - enh: improved support for tdms data (dclab 0.12.0 -> 0.14.5) (e.g. #249)
  - fix: remove nan/inf values before performing (g)lmm analysis (#248)
  - docs: request citation of Herbig2018 when performing (g)lmm analysis
 0.9.5

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.9.6
+ - fix: remove nan/inf values before performing (g)lmm analysis (#248)
 0.9.5
  - fix: Allow to open measurement files that do not contain the features
    "area_um" or "deform" (#245)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 0.9.6
- - enh: improved support for .tdms file format (dclab 0.14.3)
+ - enh: improved support for .tdms file format (dclab 0.12.0 -> 0.14.4)
  - fix: remove nan/inf values before performing (g)lmm analysis (#248)
  - docs: request citation of Herbig2018 when performing (g)lmm analysis
 0.9.5

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 0.9.6
- - enh: improved support for tdms data (dclab 0.12.0 -> 0.14.5) (e.g. #249)
+ - enh: improved support for tdms data (dclab 0.12.0 -> 0.14.6) (e.g. #249)
  - fix: remove nan/inf values before performing (g)lmm analysis (#248)
  - docs: request citation of Herbig2018 when performing (g)lmm analysis
 0.9.5

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,6 @@ To compile the documentation, run
 
 Notes
 =====
-To view the sphinx inventory of DryMass, run
+To view the sphinx inventory of Shape-Out, run
 
    python -m sphinx.ext.intersphinx 'http://shapeout.readthedocs.io/en/develop/objects.inv'

--- a/docs/sec_interface.rst
+++ b/docs/sec_interface.rst
@@ -336,6 +336,8 @@ Regression analysis:
   Perform a regression analysis according to (general) linear mixed effects
   models. For more information, please see :ref:`sec_qg_mixed_effects` as
   well as the references :cite:`Herbig2017` and :cite:`Herbig2018`.
+  If you are using this feature in a scientific publication, please
+  consider citing :cite:`Herbig2018`.
 
 
 Plotting tabs

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
                                ],
                       },
     install_requires=["appdirs",
-                      "dclab[all]>=0.14.1",
+                      "dclab[all]>=0.14.3",
                       "fcswrite>=0.4.1",
                       "h5py>=2.8.0",
                       "imageio>=2.3.0,<2.5.0",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
                                ],
                       },
     install_requires=["appdirs",
-                      "dclab[all]>=0.14.5",
+                      "dclab[all]>=0.14.6",
                       "fcswrite>=0.4.1",
                       "h5py>=2.8.0",
                       "imageio>=2.3.0,<2.5.0",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
                                ],
                       },
     install_requires=["appdirs",
-                      "dclab[all]>=0.12.0",
+                      "dclab[all]>=0.14.1",
                       "fcswrite>=0.4.1",
                       "h5py>=2.8.0",
                       "imageio>=2.3.0,<2.5.0",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
                                ],
                       },
     install_requires=["appdirs",
-                      "dclab[all]>=0.14.3",
+                      "dclab[all]>=0.14.4",
                       "fcswrite>=0.4.1",
                       "h5py>=2.8.0",
                       "imageio>=2.3.0,<2.5.0",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
                       },
     install_requires=["appdirs",
                       "dclab[all]>=0.14.6",
-                      "fcswrite>=0.4.1",
+                      "fcswrite>=0.5.0",
                       "h5py>=2.8.0",
                       "imageio>=2.3.0,<2.5.0",
                       "nptdms",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
                                ],
                       },
     install_requires=["appdirs",
-                      "dclab[all]>=0.14.4",
+                      "dclab[all]>=0.14.5",
                       "fcswrite>=0.4.1",
                       "h5py>=2.8.0",
                       "imageio>=2.3.0,<2.5.0",

--- a/shapeout/gui/controls_analyze.py
+++ b/shapeout/gui/controls_analyze.py
@@ -211,7 +211,7 @@ class SubPanelAnalyze(SubPanel):
             if self.WXCB_treatment[ii].GetSelection() == 0:
                 # The user selected "None"
                 continue
-            xs.append(mm[axname][mm._filter])
+            xs.append(mm[axname][mm.filter.all])
             mmtreat = self.WXCB_treatment[ii].GetValue()
             treatment.append(mmtreat)
             # get repetition

--- a/shapeout/gui/controls_analyze.py
+++ b/shapeout/gui/controls_analyze.py
@@ -231,7 +231,21 @@ class SubPanelAnalyze(SubPanel):
         # write to temporary file and display with webbrowser
         outf = tempfile.mktemp(prefix="regression_analysis_{}_".format(axname),
                                suffix=".txt")
+        # add citation request
+        citreq = [
+            "# If you are using these results in a scientific publication,",
+            "# please consider citing the following manuscript:",
+            "#",
+            "#  Herbig M, Mietke A, Müller P, Otto O (2018)",
+            "#  Statistics for real-time deformability cytometry: Clustering,",
+            "#  dimensionality reduction, and significance testing.",
+            "#  Biomicrofluidics 12:042214. doi: 10.1063/1.5027197",
+            "#",
+            "",
+            ]
+
         with io.open(outf, "w") as fd:
+            fd.writelines(citreq)
             fd.writelines(result["Full Summary"].replace("\n", "\r\n"))
 
         webbrowser.open(fd.name)

--- a/shapeout/gui/controls_analyze.py
+++ b/shapeout/gui/controls_analyze.py
@@ -245,7 +245,7 @@ class SubPanelAnalyze(SubPanel):
             ]
 
         with io.open(outf, "w") as fd:
-            fd.writelines(citreq)
+            fd.writelines([ll + "\r\n" for ll in citreq])
             fd.writelines(result["Full Summary"].replace("\n", "\r\n"))
 
         webbrowser.open(fd.name)

--- a/shapeout/gui/export.py
+++ b/shapeout/gui/export.py
@@ -11,6 +11,8 @@ import numpy as np
 import wx
 from wx.lib.scrolledpanel import ScrolledPanel
 
+from .._version import version
+
 
 class ExportAnalysisEvents(wx.Frame):
     def __init__(self, parent, analysis, ext="ext", non_scalars=[]):
@@ -179,6 +181,7 @@ class ExportAnalysisEventsFCS(ExportAnalysisEvents):
             m.export.fcs(os.path.join(out_dir, m.title+".fcs"),
                          mfeat,
                          filtered=filtered,
+                         meta_data={"Shape-Out version": version},
                          override=True)
 
 
@@ -213,6 +216,7 @@ class ExportAnalysisEventsTSV(ExportAnalysisEvents):
             m.export.tsv(os.path.join(out_dir, m.title+".tsv"),
                          mfeat,
                          filtered=filtered,
+                         meta_data={"Shape-Out version": version},
                          override=True)
 
 

--- a/shapeout/lin_mix_mod.py
+++ b/shapeout/lin_mix_mod.py
@@ -364,6 +364,12 @@ def linmixmod(xs, treatment, timeunit, model='lmm', RCMD=cran.rcmd):
     timeunit = list(timeunit[~invalid])
     xs = [xi for ii, xi in enumerate(xs) if ~invalid[ii]]
 
+    # convert to ndarray
+    xs = [np.array(xi, dtype=float) for xi in xs]
+
+    # remove nan/inf values
+    xs = [xi[~np.logical_or(np.isnan(xi), np.isinf(xi))] for xi in xs]
+
     ######################Differential Deformation#############################
     # If the user selected 'Control-Reservoir' and/or 'Treatment-Reservoir'
     Median_DiffDef = []

--- a/tests/test_linmixmod.py
+++ b/tests/test_linmixmod.py
@@ -33,6 +33,24 @@ def test_linmixmod():
     assert np.allclose([res["Estimate"]], [136.63650509])
 
 
+def test_linmixmod_nan():
+    treatment = ['Control', 'Treatment', 'Control', 'Treatment']
+    timeunit = [1, 1, 2, 2]
+    xs = [
+        [100, np.inf, 80, np.nan, 140, 150, 100, 100, 110, 111, 140, 145],
+        [115, 110, 90, 110, 145, 155, 110, 120, 115, 120, 120, 150,
+         100, 90, 100],
+        [150, 150, 130, 170, 190, 250, 150, 150, 160,
+         161, 180, 195, 130, 120, 125, 130, 125],
+        [155, 155, 135, 175, 195, 255, 155, 155, 165, 165,
+         185, 200, 135, 125, 130, 135, 140, 150, 135, 140]
+    ]
+
+    res = linmixmod(xs=xs, treatment=treatment, timeunit=timeunit)
+
+    assert np.allclose([res["Estimate"]], [137.37179302516199186])
+
+
 if __name__ == "__main__":
     # Run all tests
     loc = locals()

--- a/tests/test_session_conversion.py
+++ b/tests/test_session_conversion.py
@@ -3,6 +3,7 @@
 from __future__ import division, print_function
 
 import numpy as np
+import pytest
 
 from shapeout.session import index, rw
 from shapeout.analysis import Analysis
@@ -53,6 +54,9 @@ def test_070hierarchy2():
     cleanup()
 
 
+@pytest.mark.filterwarnings('ignore::dclab.rtdc_dataset.'
+                            + 'ancillaries.ancillary_feature.'
+                            + 'BadFeatureSizeWarning')
 def test_074hierarchy2():
     analysis = compatibility_task("session_v0.7.4_hierarchy2.zmso")
 


### PR DESCRIPTION
 - enh: improved support for tdms data (dclab 0.12.0 -> 0.14.7) (e.g. #249)
 - enh: write Shape-Out version to exported .fcs and .tsv files (#250)
 - fix: remove nan/inf values before performing (g)lmm analysis (#248)
 - docs: request citation of Herbig2018 when performing (g)lmm analysis